### PR TITLE
Replace boolean type with bool in examples

### DIFF
--- a/examples/ArduinoYun/SendAnEmail/SendAnEmail.ino
+++ b/examples/ArduinoYun/SendAnEmail/SendAnEmail.ino
@@ -70,7 +70,7 @@ const String GMAIL_APP_PASSWORD = "xxxxxxxxxx";
 const String TO_EMAIL_ADDRESS = "xxxxxxxxxx";
 
 // a flag to indicate whether we've tried to send the email yet or not
-boolean attempted = false; 
+bool attempted = false; 
 
 void setup() {
   Serial.begin(9600);

--- a/examples/ArduinoYun/SendAnSMS/SendAnSMS.ino
+++ b/examples/ArduinoYun/SendAnSMS/SendAnSMS.ino
@@ -55,7 +55,7 @@ const String TWILIO_NUMBER = "xxxxxxxxxx";
 const String RECIPIENT_NUMBER = "xxxxxxxxxx";
 
 // a flag to indicate whether we've attempted to send the SMS yet or not
-boolean attempted = false; 
+bool attempted = false; 
 
 void setup() {
   Serial.begin(9600);

--- a/examples/ArduinoYun/UploadToDropbox/UploadToDropbox.ino
+++ b/examples/ArduinoYun/UploadToDropbox/UploadToDropbox.ino
@@ -53,7 +53,7 @@ const String DROPBOX_ACCESS_TOKEN = "xxxxxxxxxx";
 const String DROPBOX_ACCESS_TOKEN_SECRET = "xxxxxxxxxx";
 
 
-boolean success = false; // a flag to indicate whether we've uploaded the file yet
+bool success = false; // a flag to indicate whether we've uploaded the file yet
 
 void setup() {
   Serial.begin(9600);


### PR DESCRIPTION
Replace boolean type with bool in examples

This is part of a move to encourage use of the standard bool type over Arduino's non-standard boolean type alias.

As approved by cmaglie: https://github.com/arduino/Arduino/issues/6657#issuecomment-355597633