### PR TITLE
Use GitHub Actions for continuous integration

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,7 @@
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = tre,messanger
+check-filenames =
+check-hidden =
+skip = ./.git

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# See: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#about-the-dependabotyml-file
+version: 2
+
+updates:
+  # Configure check for outdated GitHub Actions actions in workflows.
+  # See: https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot
+  - package-ecosystem: github-actions
+    directory: / # Check the repository's workflows under /.github/workflows/
+    schedule:
+      interval: daily

--- a/.github/workflows/check-arduino.yml
+++ b/.github/workflows/check-arduino.yml
@@ -1,0 +1,28 @@
+name: Check Arduino
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by new rules added to Arduino Lint.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Arduino Lint
+        uses: arduino/arduino-lint-action@v1
+        with:
+          compliance: specification
+          library-manager: update
+          # Always use this setting for official repositories. Remove for 3rd party projects.
+          official: true
+          project-type: library

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -25,6 +25,9 @@ jobs:
     name: ${{ matrix.board.fqbn }}
     runs-on: ubuntu-latest
 
+    env:
+      SKETCHES_REPORTS_PATH: sketches-reports
+
     strategy:
       fail-fast: false
 
@@ -86,3 +89,12 @@ jobs:
             - name: Bridge
           sketch-paths: |
             ${{ matrix.sketch-paths }}
+          enable-deltas-report: true
+          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
+
+      - name: Save sketches report as workflow artifact
+        uses: actions/upload-artifact@v2
+        with:
+          if-no-files-found: error
+          path: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,0 +1,88 @@
+name: Compile Examples
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "library.properties"
+      - "examples/**"
+      - "src/**"
+  pull_request:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "library.properties"
+      - "examples/**"
+      - "src/**"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by changes to external resources (libraries, platforms).
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  build:
+    name: ${{ matrix.board.fqbn }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        board:
+          - fqbn: arduino:avr:uno
+            platforms: |
+              - name: arduino:avr
+            yun: false
+          - fqbn: arduino:avr:mega
+            platforms: |
+              - name: arduino:avr
+            yun: false
+          - fqbn: arduino:avr:leonardo
+            platforms: |
+              - name: arduino:avr
+            yun: false
+          - fqbn: arduino:avr:yun
+            platforms: |
+              - name: arduino:avr
+            yun: true
+          - fqbn: arduino:megaavr:uno2018
+            platforms: |
+              - name: arduino:megaavr
+            yun: false
+          - fqbn: arduino:sam:arduino_due_x_dbg
+            platforms: |
+              - name: arduino:sam
+          - fqbn: arduino:samd:arduino_zero_edbg
+            platforms: |
+              - name: arduino:samd
+            yun: false
+
+        # make board type-specific customizations to the matrix jobs
+        include:
+          - board:
+              yun: true
+            sketch-paths: |
+              - examples/ArduinoYun
+          - board:
+              yun: false
+            sketch-paths: |
+              - examples/YunShield
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Compile examples
+        uses: arduino/compile-sketches@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fqbn: ${{ matrix.board.fqbn }}
+          platforms: ${{ matrix.board.platforms }}
+          libraries: |
+            # Install the library from the local path.
+            - source-path: ./
+            # Additional library dependencies
+            - name: Bridge
+          sketch-paths: |
+            ${{ matrix.sketch-paths }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -1,0 +1,24 @@
+name: Report Size Deltas
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/report-size-deltas.yml"
+  schedule:
+    # Run at the minimum interval allowed by GitHub Actions.
+    # Note: GitHub Actions periodically has outages which result in workflow failures.
+    # In this event, the workflows will start passing again once the service recovers.
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment size deltas reports to PRs
+        uses: arduino/report-size-deltas@v1
+        with:
+          # The name of the workflow artifact created by the sketch compilation workflow
+          sketches-reports-source: sketches-reports

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,22 @@
+name: Spell Check
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Spell check
+        uses: codespell-project/actions-codespell@master

--- a/README.adoc
+++ b/README.adoc
@@ -4,6 +4,7 @@
 = {repository-name} Library for Arduino =
 
 image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-arduino.yml/badge.svg["Check Arduino status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-arduino.yml"]
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/compile-examples.yml/badge.svg["Compile Examples status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/compile-examples.yml"]
 image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml/badge.svg["Spell Check status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml"]
 
 This library allows an Arduino to connect to the Temboo service.

--- a/README.adoc
+++ b/README.adoc
@@ -3,6 +3,7 @@
 
 = {repository-name} Library for Arduino =
 
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-arduino.yml/badge.svg["Check Arduino status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-arduino.yml"]
 image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml/badge.svg["Spell Check status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml"]
 
 This library allows an Arduino to connect to the Temboo service.

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,9 @@
-= Temboo Library for Arduino =
+:repository-owner: arduino-libraries
+:repository-name: Temboo
+
+= {repository-name} Library for Arduino =
+
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml/badge.svg["Spell Check status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml"]
 
 This library allows an Arduino to connect to the Temboo service.
 

--- a/examples/ArduinoYun/GetYahooWeatherReport/GetYahooWeatherReport.ino
+++ b/examples/ArduinoYun/GetYahooWeatherReport/GetYahooWeatherReport.ino
@@ -54,15 +54,15 @@ void loop()
     // invoke the Temboo client
     GetWeatherByAddressChoreo.begin();
 
-    // add your temboo account info
+    // add your Temboo account info
     GetWeatherByAddressChoreo.setAccountName(TEMBOO_ACCOUNT);
     GetWeatherByAddressChoreo.setAppKeyName(TEMBOO_APP_KEY_NAME);
     GetWeatherByAddressChoreo.setAppKey(TEMBOO_APP_KEY);
     
-    // set the name of the choreo we want to run
+    // set the name of the Choreo we want to run
     GetWeatherByAddressChoreo.setChoreo("/Library/Yahoo/Weather/GetWeatherByAddress");
     
-    // set choreo inputs; in this case, the address for which to retrieve weather data
+    // set Choreo inputs; in this case, the address for which to retrieve weather data
     // the Temboo client provides standardized calls to 100+ cloud APIs
     GetWeatherByAddressChoreo.addInput("Address", ADDRESS_FOR_FORECAST);
 
@@ -75,10 +75,10 @@ void loop()
     // add an output filter to extract the date and time of the last report.
     GetWeatherByAddressChoreo.addOutputFilter("date", "/rss/channel/item/yweather:condition/@date", "Response");
 
-    // run the choreo 
+    // run the Choreo 
     GetWeatherByAddressChoreo.run();
         
-    // when the choreo results are available, print them to the serial monitor
+    // when the Choreo results are available, print them to the Serial Monitor
     while(GetWeatherByAddressChoreo.available()) {
           
       char c = GetWeatherByAddressChoreo.read();    

--- a/examples/ArduinoYun/ReadATweet/ReadATweet.ino
+++ b/examples/ArduinoYun/ReadATweet/ReadATweet.ino
@@ -19,7 +19,7 @@
   is connected to the Internet.
 
   Want to use another social API with your Arduino Yún? We've got Facebook,
-  Google+, Instagram, Tumblr and more in our Library!
+  Instagram, Tumblr and more in our Library!
   
   This example code is in the public domain.
 */
@@ -71,7 +71,7 @@ void loop()
     HomeTimelineChoreo.setChoreo("/Library/Twitter/Timelines/HomeTimeline");
     
     
-    // set the required choreo inputs
+    // set the required Choreo inputs
     // see https://www.temboo.com/library/Library/Twitter/Timelines/HomeTimeline/
     // for complete details about the inputs for this Choreo
 
@@ -105,7 +105,7 @@ void loop()
       String tweet; // a String to hold the text of the tweet
 
 
-      // choreo outputs are returned as key/value pairs, delimited with 
+      // Choreo outputs are returned as key/value pairs, delimited with 
       // newlines and record/field terminator characters, for example:
       // Name1\n\x1F
       // Value1\n\x1E
@@ -136,7 +136,7 @@ void loop()
     
     } else {
       // there was an error
-      // print the raw output from the choreo
+      // print the raw output from the Choreo
       while(HomeTimelineChoreo.available()) {
         char c = HomeTimelineChoreo.read();
         Serial.print(c);

--- a/examples/ArduinoYun/SendATweet/SendATweet.ino
+++ b/examples/ArduinoYun/SendATweet/SendATweet.ino
@@ -20,7 +20,7 @@
   to the Internet.
 
   Want to use another social API with your Arduino Yún? We've got Facebook,
-  Google+, Instagram, Tumblr and more in our Library!
+  Instagram, Tumblr and more in our Library!
   
   This example code is in the public domain.
 */
@@ -76,10 +76,10 @@ void loop()
     StatusesUpdateChoreo.setAppKeyName(TEMBOO_APP_KEY_NAME);
     StatusesUpdateChoreo.setAppKey(TEMBOO_APP_KEY);
 
-    // identify the Temboo Library choreo to run (Twitter > Tweets > StatusesUpdate)
+    // identify the Temboo Library Choreo to run (Twitter > Tweets > StatusesUpdate)
     StatusesUpdateChoreo.setChoreo("/Library/Twitter/Tweets/StatusesUpdate");
 
-    // set the required choreo inputs
+    // set the required Choreo inputs
     // see https://www.temboo.com/library/Library/Twitter/Tweets/StatusesUpdate/ 
     // for complete details about the inputs for this Choreo
  

--- a/examples/ArduinoYun/SendAnEmail/SendAnEmail.ino
+++ b/examples/ArduinoYun/SendAnEmail/SendAnEmail.ino
@@ -34,7 +34,7 @@
  
   9. Copy and paste this password into the code below, updating the GMAIL_APP_PASSWORD variable
  
-  10. Upload the sketch to your Arduino Yún and open the serial monitor
+  10. Upload the sketch to your Arduino Yún and open the Serial Monitor
   
   NOTE: You can test this Choreo and find the latest instructions on our website: 
   https://temboo.com/library/Library/Google/Gmail/SendEmail
@@ -101,11 +101,11 @@ void loop()
     SendEmailChoreo.setAppKeyName(TEMBOO_APP_KEY_NAME);
     SendEmailChoreo.setAppKey(TEMBOO_APP_KEY);
 
-    // identify the Temboo Library choreo to run (Google > Gmail > SendEmail)
+    // identify the Temboo Library Choreo to run (Google > Gmail > SendEmail)
     SendEmailChoreo.setChoreo("/Library/Google/Gmail/SendEmail");
  
 
-    // set the required choreo inputs
+    // set the required Choreo inputs
     // see https://www.temboo.com/library/Library/Google/Gmail/SendEmail/ 
     // for complete details about the inputs for this Choreo
 

--- a/examples/ArduinoYun/SendAnSMS/SendAnSMS.ino
+++ b/examples/ArduinoYun/SendAnSMS/SendAnSMS.ino
@@ -87,10 +87,10 @@ void loop()
     SendSMSChoreo.setAppKeyName(TEMBOO_APP_KEY_NAME);
     SendSMSChoreo.setAppKey(TEMBOO_APP_KEY);
 
-    // identify the Temboo Library choreo to run (Twilio > SMSMessages > SendSMS)
+    // identify the Temboo Library Choreo to run (Twilio > SMSMessages > SendSMS)
     SendSMSChoreo.setChoreo("/Library/Twilio/SMSMessages/SendSMS");
 
-    // set the required choreo inputs
+    // set the required Choreo inputs
     // see https://www.temboo.com/library/Library/Twilio/SMSMessages/SendSMS/ 
     // for complete details about the inputs for this Choreo
 
@@ -127,7 +127,7 @@ void loop()
     } 
     SendSMSChoreo.close();
     
-    // set the flag indicatine we've tried once.
+    // set the flag indicating we've tried once.
     attempted=true;
   }
 }

--- a/examples/ArduinoYun/SendDataToGoogleSpreadsheet/SendDataToGoogleSpreadsheet.ino
+++ b/examples/ArduinoYun/SendDataToGoogleSpreadsheet/SendDataToGoogleSpreadsheet.ino
@@ -42,7 +42,7 @@
      
      https://temboo.com/arduino/yun/update-google-spreadsheet
  
-  6. Next, upload the sketch to your Arduino Yún and open the serial monitor
+  6. Next, upload the sketch to your Arduino Yún and open the Serial Monitor
   
      Note: you can test this Choreo and find the latest instructions on our website:
      https://temboo.com/library/Library/Google/Sheets/AppendValues/
@@ -106,7 +106,7 @@ void loop()
   // run again if it's been 60 seconds since we last ran
   if (now - lastRun >= RUN_INTERVAL_MILLIS) {
 
-    // remember 'now' as the last time we ran the choreo
+    // remember 'now' as the last time we ran the Choreo
     lastRun = now;
     
     Serial.println("Getting sensor value...");
@@ -129,7 +129,7 @@ void loop()
     AppendValuesChoreo.setAppKeyName(TEMBOO_APP_KEY_NAME);
     AppendValuesChoreo.setAppKey(TEMBOO_APP_KEY);
     
-    // identify the Temboo Library choreo to run (Google > Sheets > AppendValues)
+    // identify the Temboo Library Choreo to run (Google > Sheets > AppendValues)
     AppendValuesChoreo.setChoreo("/Library/Google/Sheets/AppendValues");
     
     // set the required Choreo inputs

--- a/examples/ArduinoYun/TembooDeviceConfig/TembooDeviceConfig.ino
+++ b/examples/ArduinoYun/TembooDeviceConfig/TembooDeviceConfig.ino
@@ -42,7 +42,7 @@ void setup() {
   }
   Serial.println();
   
-  // install python openssl to allow for for ssl connections
+  // install python openssl to allow for SSL connections
   Serial.print("Installing python-openssl...");
   p.runShellCommand("opkg install python-openssl");
   returnCode = p.exitValue();

--- a/examples/ArduinoYun/ToxicFacilitiesSearch/ToxicFacilitiesSearch.ino
+++ b/examples/ArduinoYun/ToxicFacilitiesSearch/ToxicFacilitiesSearch.ino
@@ -60,10 +60,10 @@ void loop()
     FacilitiesSearchByZipChoreo.setAppKeyName(TEMBOO_APP_KEY_NAME);
     FacilitiesSearchByZipChoreo.setAppKey(TEMBOO_APP_KEY);
   
-    // identify the Temboo Library choreo to run (EnviroFacts > Toxins > FacilitiesSearchByZip)
+    // identify the Temboo Library Choreo to run (EnviroFacts > Toxins > FacilitiesSearchByZip)
     FacilitiesSearchByZipChoreo.setChoreo("/Library/EnviroFacts/Toxins/FacilitiesSearchByZip");
         
-    // set choreo inputs; in this case, the US zip code for which to retrieve toxin release data
+    // set Choreo inputs; in this case, the US zip code for which to retrieve toxin release data
     // the Temboo client provides standardized calls to 100+ cloud APIs
     FacilitiesSearchByZipChoreo.addInput("Zip", US_ZIP_CODE);
     
@@ -73,13 +73,13 @@ void loop()
 
     FacilitiesSearchByZipChoreo.addOutputFilter("addr", "STREET_ADDRESS", "Response");
 
-    // run the choreo 
+    // run the Choreo 
     unsigned int returnCode = FacilitiesSearchByZipChoreo.run();
     if (returnCode == 0) {
       String facilities;
       String addresses;
 
-      // when the choreo results are available, process them.
+      // when the Choreo results are available, process them.
       // the output filters we specified will return comma delimited
       // lists containing the name and street address of the facilities
       // located in the specified zip code.
@@ -99,7 +99,7 @@ void loop()
       FacilitiesSearchByZipChoreo.close();
       
       // parse the comma delimited lists of facilities to join the 
-      // name with the address and print it to the serial monitor
+      // name with the address and print it to the Serial Monitor
       if (facilities.length() > 0) {
         int i = -1;
         int facilityStart = 0;
@@ -142,7 +142,7 @@ void loop()
   delay(30000); // wait 30 seconds between calls
 }
 
-// a simple utility function, to output the facility name and address in the serial monitor.
+// a simple utility function, to output the facility name and address in the Serial Monitor.
 void printResult(String facility, String address) {
   Serial.print(facility);
   Serial.print(" - ");

--- a/examples/ArduinoYun/UpdateFacebookStatus/UpdateFacebookStatus.ino
+++ b/examples/ArduinoYun/UpdateFacebookStatus/UpdateFacebookStatus.ino
@@ -18,7 +18,7 @@
   This example assumes basic familiarity with Arduino sketches, and that your Yún
   is connected to the Internet.
   
-  Want to use another social API with your Arduino Yún? We've got Twitter, Google+,
+  Want to use another social API with your Arduino Yún? We've got Twitter,
   Instagram, Tumblr and more in our Library!
 
   This example code is in the public domain. 
@@ -77,7 +77,7 @@ void loop() {
     // tell the Temboo client which Choreo to run (Facebook > Publishing > SetStatus)
     SetStatusChoreo.setChoreo("/Library/Facebook/Publishing/SetStatus");
 
-    // set the required choreo inputs
+    // set the required Choreo inputs
     // see  https://www.temboo.com/library/Library/Facebook/Publishing/SetStatus/
     // for complete details about the inputs for this Choreo
     

--- a/examples/ArduinoYun/UploadToDropbox/UploadToDropbox.ino
+++ b/examples/ArduinoYun/UploadToDropbox/UploadToDropbox.ino
@@ -90,10 +90,10 @@ void loop()
     UploadFileChoreo.setAppKeyName(TEMBOO_APP_KEY_NAME);
     UploadFileChoreo.setAppKey(TEMBOO_APP_KEY);
 
-    // identify the Temboo Library choreo to run (Dropbox > FilesAndMetadata > UploadFile)
+    // identify the Temboo Library Choreo to run (Dropbox > FilesAndMetadata > UploadFile)
     UploadFileChoreo.setChoreo("/Library/Dropbox/FilesAndMetadata/UploadFile");
     
-    // set the required choreo inputs
+    // set the required Choreo inputs
     // see https://www.temboo.com/library/Library/Dropbox/FilesAndMetadata/UploadFile/
     // for complete details about the inputs for this Choreo
 
@@ -128,7 +128,7 @@ void loop()
       Serial.println("Uh-oh! Something went wrong!");
     }
     
-    // print out the full response to the serial monitor in all
+    // print out the full response to the Serial Monitor in all
     // cases, just for debugging
     while (UploadFileChoreo.available()) {
       char c = UploadFileChoreo.read();
@@ -160,17 +160,17 @@ String base64Encode(String toEncode) {
     Base64EncodeChoreo.setAppKeyName(TEMBOO_APP_KEY_NAME);
     Base64EncodeChoreo.setAppKey(TEMBOO_APP_KEY);
 
-    // identify the Temboo Library choreo to run (Utilities > Encoding > Base64Encode)
+    // identify the Temboo Library Choreo to run (Utilities > Encoding > Base64Encode)
     Base64EncodeChoreo.setChoreo("/Library/Utilities/Encoding/Base64Encode");
  
-     // set choreo inputs
+     // set Choreo inputs
     Base64EncodeChoreo.addInput("Text", toEncode);
     
-    // run the choreo
+    // run the Choreo
     Base64EncodeChoreo.run();
     
-    // read in the choreo results, and return the "Base64EncodedText" output value.
-    // see http://www.temboo.com/arduino for more details on using choreo outputs.
+    // read in the Choreo results, and return the "Base64EncodedText" output value.
+    // see http://www.temboo.com/arduino for more details on using Choreo outputs.
     while(Base64EncodeChoreo.available()) {
       // read the name of the output item
       String name = Base64EncodeChoreo.readStringUntil('\x1F');

--- a/examples/YunShield/TembooDeviceConfig/TembooDeviceConfig.ino
+++ b/examples/YunShield/TembooDeviceConfig/TembooDeviceConfig.ino
@@ -43,7 +43,7 @@ void setup() {
   }
   Serial.println();
   
-  // install python openssl to allow for for ssl connections
+  // install python openssl to allow for for SSL connections
   Serial.print("Installing python-openssl...");
   p.runShellCommand("opkg install python-openssl");
   returnCode = p.exitValue();

--- a/library.properties
+++ b/library.properties
@@ -1,8 +1,8 @@
 name=Temboo
 author=Temboo
 maintainer=Temboo <support@temboo.com>
-sentence=This library enables calls to Temboo, a platform that connects Arduino/Genuino boards to 100+ APIs, databases, code utilities and more. 
-paragraph=Use this library to connect your Arduino or Genuino board to Temboo, making it simple to interact with a vast array of web-based resources and services.
+sentence=This library enables calls to Temboo, a platform that connects Arduino boards to 100+ APIs, databases, code utilities and more. 
+paragraph=Use this library to connect your Arduino board to Temboo, making it simple to interact with a vast array of web-based resources and services.
 category=Communication
 url=http://www.temboo.com/arduino
 architectures=*

--- a/src/Temboo.h
+++ b/src/Temboo.h
@@ -107,22 +107,22 @@ class TembooChoreo : public Stream {
         void setAccountName(const String& accountName);
         void setAccountName(const char* accountName);
 
-        // Sets the application key name to use with choreo execution requests.
+        // Sets the application key name to use with Choreo execution requests.
         // (required)
         void setAppKeyName(const String& appKeyName);
         void setAppKeyName(const char* appKeyName);
         
-        // Sets the application key value to use with choreo execution requests
+        // Sets the application key value to use with Choreo execution requests
         // (required)
         void setAppKey(const String& appKey);
         void setAppKey(const char* appKey);
         
-        // Sets the name of the choreo to be executed.
+        // Sets the name of the Choreo to be executed.
         // (required)
         void setChoreo(const String& choreoPath);
         void setChoreo(const char* choreoPath);
         
-        // Sets the name of the saved inputs to use when executing the choreo
+        // Sets the name of the saved inputs to use when executing the Choreo
         // (optional)
         void setSavedInputs(const String& savedInputsName);
         void setSavedInputs(const char* savedInputsName);
@@ -139,8 +139,8 @@ class TembooChoreo : public Stream {
         void setDeviceName(const String& deviceName);
         void setDeviceName(const char* deviceName);
 
-        // Sets an input to be used when executing a choreo.
-        // (optional or required, depending on the choreo being executed.)
+        // Sets an input to be used when executing a Choreo.
+        // (optional or required, depending on the Choreo being executed.)
         void addInput(const String& inputName, const String& inputValue);
         void addInput(const char* inputName, const char* inputValue);
         void addInput(const char* inputName, const String& inputValue);
@@ -167,7 +167,7 @@ class TembooChoreo : public Stream {
         void addSensorInput(const char* sensorName, int sensorValue, const char* conversion, const char* calibrationValue);
         void addSensorInput(const char* sensorName, int sensorValue, const char* rawLow, const char* rawHigh, const char* scaleLow, const char* scaleHigh);
 
-        // Sets an output filter to be used to process the choreo output
+        // Sets an output filter to be used to process the Choreo output
         // (optional)
         void addOutputFilter(const char* filterName, const char* filterPath, const char* variableName);
         void addOutputFilter(const String& filterName, const char* filterPath, const char* variableName);
@@ -178,12 +178,12 @@ class TembooChoreo : public Stream {
         void addOutputFilter(const char* filterName, const String& filterPath, const String& variableName);
         void addOutputFilter(const String& filterName, const String& filterPath, const String& variableName);
        
-        // Run the choreo using the current input info
+        // Run the Choreo using the current input info
         int run();
-        // Run the choreo with a user specified timeout
+        // Run the Choreo with a user specified timeout
         int run(uint16_t timeoutSecs);
     
-        // Run the choreo on the Temboo server at the given IP address and port
+        // Run the Choreo on the Temboo server at the given IP address and port
         int run(IPAddress addr, uint16_t port);
         int run(IPAddress addr, uint16_t port, uint16_t timeoutSecs);
 

--- a/src/TembooCoAPEdgeDevice.cpp
+++ b/src/TembooCoAPEdgeDevice.cpp
@@ -804,7 +804,7 @@ int TembooCoAPChoreo::run(uint16_t timeoutSecs) {
             }
         }
         
-        // choreo request complete, wait for CON from gateway
+        // Choreo request complete, wait for CON from gateway
         // and then request the rest of the response
         
         rc = waitForResponse(timer);
@@ -826,7 +826,7 @@ int TembooCoAPChoreo::run(uint16_t timeoutSecs) {
             
             m_nextChar = HTTP_CODE_PREFIX;
             
-            //Unauthroized, need to update the time
+            //Unauthorized, need to update the time
             if (httpCode == 401 && i == 0) {
                 find(HEADER_TIME);
                 TembooCoAPSession::setTime((unsigned long)this->parseInt());

--- a/src/TembooCoAPEdgeDevice.h
+++ b/src/TembooCoAPEdgeDevice.h
@@ -196,23 +196,23 @@ class TembooCoAPChoreo : public Stream {
         void setAccountName(const String& accountName);
         void setAccountName(const char* accountName);
         
-        // Sets the application key name to use with choreo execution requests.
+        // Sets the application key name to use with Choreo execution requests.
         // (required)
         void setAppKeyName(const String& appKeyName);
         void setAppKeyName(const char* appKeyName);
         
-        // Sets the application key value to use with choreo execution requests
+        // Sets the application key value to use with Choreo execution requests
         // (required)
         void setAppKey(const String& appKey);
         void setAppKey(const char* appKey);
         
-        // sets the name of the choreo to be executed.
+        // sets the name of the Choreo to be executed.
         // (required)
         void setChoreo(const String& choreoPath);
         void setChoreo(const char* choreoPath);
         
         
-        // sets the name of the saved inputs to use when executing the choreo
+        // sets the name of the saved inputs to use when executing the Choreo
         // (optional)
         void setSavedInputs(const String& savedInputsName);
         void setSavedInputs(const char* savedInputsName);
@@ -223,14 +223,14 @@ class TembooCoAPChoreo : public Stream {
         void setProfile(const String& profileName);
         void setProfile(const char* profileName);
         
-        // sets an input to be used when executing a choreo.
-        // (optional or required, depending on the choreo being executed.)
+        // sets an input to be used when executing a Choreo.
+        // (optional or required, depending on the Choreo being executed.)
         void addInput(const String& inputName, const String& inputValue);
         void addInput(const char* inputName, const char* inputValue);
         void addInput(const char* inputName, const String& inputValue);
         void addInput(const String& inputName, const char* inputValue);
         
-        // sets an output filter to be used to process the choreo output
+        // sets an output filter to be used to process the Choreo output
         // (optional)
         void addOutputFilter(const char* filterName, const char* filterPath, const char* variableName);
         void addOutputFilter(const String& filterName, const char* filterPath, const char* variableName);
@@ -241,7 +241,7 @@ class TembooCoAPChoreo : public Stream {
         void addOutputFilter(const char* filterName, const String& filterPath, const String& variableName);
         void addOutputFilter(const String& filterName, const String& filterPath, const String& variableName);
         
-        // run the choreo using the current input info
+        // run the Choreo using the current input info
         int run(uint16_t timeoutSecs = DEFAULT_CHOREO_TIMEOUT);
         
         char* getResponseData() {return m_respData;}

--- a/src/TembooMQTTEdgeDevice.cpp
+++ b/src/TembooMQTTEdgeDevice.cpp
@@ -189,7 +189,7 @@ void handleResponseMessage(MQTT::MessageData& md) {
     }
 
     // FINALLY, everything's OK. 
-    // pass the value to the waiting choreo.
+    // pass the value to the waiting Choreo.
     g_currentChoreo->setHTTPResponseCode(next);
     TEMBOO_TRACELN(" ok");
 
@@ -294,7 +294,7 @@ void handleAckMessage(MQTT::MessageData& md) {
     }
 
     // FINALLY, everything's OK. 
-    // pass the value to the waiting choreo.
+    // pass the value to the waiting Choreo.
     g_currentChoreo->setAckCode(ackCode);
     TEMBOO_TRACELN(" ok");
 

--- a/src/TembooMQTTEdgeDevice.h
+++ b/src/TembooMQTTEdgeDevice.h
@@ -133,23 +133,23 @@ class TembooMQTTChoreo : public Stream {
         void setAccountName(const String& accountName);
         void setAccountName(const char* accountName);
 
-        // Sets the application key name to use with choreo execution requests.
+        // Sets the application key name to use with Choreo execution requests.
         // (required)
         void setAppKeyName(const String& appKeyName);
         void setAppKeyName(const char* appKeyName);
         
-        // Sets the application key value to use with choreo execution requests
+        // Sets the application key value to use with Choreo execution requests
         // (required)
         void setAppKey(const String& appKey);
         void setAppKey(const char* appKey);
         
-        // sets the name of the choreo to be executed.
+        // sets the name of the Choreo to be executed.
         // (required)
         void setChoreo(const String& choreoPath);
         void setChoreo(const char* choreoPath);
 
         
-        // sets the name of the saved inputs to use when executing the choreo
+        // sets the name of the saved inputs to use when executing the Choreo
         // (optional)
         void setSavedInputs(const String& savedInputsName);
         void setSavedInputs(const char* savedInputsName);
@@ -160,14 +160,14 @@ class TembooMQTTChoreo : public Stream {
         void setProfile(const String& profileName);
         void setProfile(const char* profileName);
 
-        // sets an input to be used when executing a choreo.
-        // (optional or required, depending on the choreo being executed.)
+        // sets an input to be used when executing a Choreo.
+        // (optional or required, depending on the Choreo being executed.)
         void addInput(const String& inputName, const String& inputValue);
         void addInput(const char* inputName, const char* inputValue);
         void addInput(const char* inputName, const String& inputValue);
         void addInput(const String& inputName, const char* inputValue);
         
-        // sets an output filter to be used to process the choreo output
+        // sets an output filter to be used to process the Choreo output
         // (optional)
         void addOutputFilter(const char* filterName, const char* filterPath, const char* variableName);
         void addOutputFilter(const String& filterName, const char* filterPath, const char* variableName);
@@ -178,7 +178,7 @@ class TembooMQTTChoreo : public Stream {
         void addOutputFilter(const char* filterName, const String& filterPath, const String& variableName);
         void addOutputFilter(const String& filterName, const String& filterPath, const String& variableName);
    
-        // run the choreo using the current input info
+        // run the Choreo using the current input info
         int run(uint16_t timeoutSecs);
 
         char* getResponseData() {return m_respData;}

--- a/src/TembooMonitoring.cpp
+++ b/src/TembooMonitoring.cpp
@@ -199,7 +199,7 @@ WSMessageRequest TembooMessaging::poll() {
 }
 
 void TembooMessaging::updatePinValue(int pinNum, int pinVal) {
-	// save the data to the strcuture and then send to Temboo
+	// save the data to the structure and then send to Temboo
 	int i = 0;
     for (; i < m_sensorTableDepth; i++) {
     	if (m_sensorTable[i]->getSensorPin(m_sensorTable[i]->sensorConfig) == pinNum) {

--- a/src/TembooSSL.h
+++ b/src/TembooSSL.h
@@ -54,13 +54,13 @@ class TembooChoreoSSL : public TembooChoreo {
         
         // Constructor.
         // client - an instance of an Arduino Client that 
-        // allows HTTPS conntections, usually WiFiSSL
+        // allows HTTPS connections, usually WiFiSSL
         TembooChoreoSSL(Client& client);
 
-        // run the choreo using the current input info
+        // run the Choreo using the current input info
         // uses port 443
         int run();
-        // run the choreo with a user specified timeout
+        // run the Choreo with a user specified timeout
         // uses port 443
         int run(uint16_t timeoutSecs);
 };

--- a/src/utility/ChoreoSensorInputFormatter.h
+++ b/src/utility/ChoreoSensorInputFormatter.h
@@ -41,7 +41,7 @@ class ChoreoSensorInputFormatter : public BaseFormatter {
         
         
         enum State {
-            // This is added to fix a compilation bug for the mkr1000
+            // This is added to fix a compilation bug for the MKR1000
             START = 256,
             SENSOR_INPUT_TAG,
             SENSOR_NAME_START,

--- a/src/utility/FP.h
+++ b/src/utility/FP.h
@@ -162,7 +162,7 @@ public:
 
     /** Invoke the function attached to the class
      *  @param arg - An argument that is passed into the function handler that is called
-     *  @return The return from the function hanlder called by this class
+     *  @return The return from the function handler called by this class
      */
     retT operator()(argT arg) const
     {
@@ -196,7 +196,7 @@ private:
     FPtrDummy *obj_callback;
 
     /**
-     *  @union Funciton
+     *  @union Function
      *  @brief Member or global callback function
      */
     union {

--- a/src/utility/MQTTClient.h
+++ b/src/utility/MQTTClient.h
@@ -117,14 +117,14 @@ public:
     }
 
     /** MQTT Connect - send an MQTT connect packet down the network and wait for a Connack
-     *  The nework object must be connected to the network endpoint before calling this
+     *  The network object must be connected to the network endpoint before calling this
      *  Default connect options are used
      *  @return success code -
      */
     int connect();
     
         /** MQTT Connect - send an MQTT connect packet down the network and wait for a Connack
-     *  The nework object must be connected to the network endpoint before calling this
+     *  The network object must be connected to the network endpoint before calling this
      *  @param options - connect options
      *  @return success code -
      */

--- a/src/utility/TembooCoAPSession.h
+++ b/src/utility/TembooCoAPSession.h
@@ -44,20 +44,20 @@ class TembooCoAPSession {
         //client: REQUIRED TembooCoAPClient client object.
         TembooCoAPSession(TembooCoAPClient& client);
         
-        //executeChoreo sends a choreo execution request to the Temboo system.
+        //executeChoreo sends a Choreo execution request to the Temboo system.
         //              Does not wait for a response (that's a job for whoever owns the Client.)
         //accountName: the name of the user's account at Temboo.
         //appKeyName: the name of an application key in the user's account to use
         //            for this execution (analogous to a user name).
         //appKeyValue: the value of the application key named in appKeyName.
         //             Used to authenticate the user (analogous to a password)
-        //path: The full path to the choreo to be executed (relative to the root of the
+        //path: The full path to the Choreo to be executed (relative to the root of the
         //      user's account.)
-        //inputSet: the set of inputs needed by the choreo.
+        //inputSet: the set of inputs needed by the Choreo.
         //          May be an empty ChoreoInputSet.
-        //outputSet: the set of output filters to be applied to the choreo results.
+        //outputSet: the set of output filters to be applied to the Choreo results.
         //           May be an empty ChoreoOutputSet
-        //preset: the ChoreoPreset to be used with the choreo execution.
+        //preset: the ChoreoPreset to be used with the Choreo execution.
         //        May be an empty ChoreoPreset.
         int executeChoreo(
                           uint16_t requestId,

--- a/src/utility/TembooDS18B20.cpp
+++ b/src/utility/TembooDS18B20.cpp
@@ -34,7 +34,7 @@ int tembooDS18B20Read(void* sensorConfig) {
 	g_wire->select(config->channel);
 	// tells device to convert temperature to scratchpad to read
 	g_wire->write(0x44, config->parasite);
-	// delay 750ms for conversion to occur, but wait for 1 second just in case
+	// delay 750 ms for conversion to occur, but wait for 1 second just in case
 	delay(config->conversionDelayMillis);
 
 	// begin reading data

--- a/src/utility/TembooMQTTIPStack.h
+++ b/src/utility/TembooMQTTIPStack.h
@@ -52,7 +52,7 @@ public:
         size_t count = m_client.readBytes((char*)buffer, len);
         
         // Not sure this is a totally good idea.
-        // (Stream defaults to 1000 mS timeouts.)
+        // (Stream defaults to 1000 ms timeouts.)
         m_client.setTimeout(1000);
         return count;
     }
@@ -82,7 +82,7 @@ public:
         size_t count = m_client.write(buffer, min(len, WRITE_CHUNK_SIZE));
         
         // Not sure this is a totally good idea.
-        // (Stream defaults to 1000 mS timeouts.)
+        // (Stream defaults to 1000 ms timeouts.)
         m_client.setTimeout(1000);
         return count;
     }

--- a/src/utility/TembooMQTTSession.h
+++ b/src/utility/TembooMQTTSession.h
@@ -44,20 +44,20 @@ class TembooMQTTSession {
         //client: REQUIRED TembooMQTTClient client object.
         TembooMQTTSession(TembooMQTTClient& client);
 
-        //executeChoreo sends a choreo execution request to the Temboo system.
+        //executeChoreo sends a Choreo execution request to the Temboo system.
         //              Does not wait for a response (that's a job for whoever owns the Client.)
         //accountName: the name of the user's account at Temboo.
         //appKeyName: the name of an application key in the user's account to use 
         //            for this execution (analogous to a user name).
         //appKeyValue: the value of the application key named in appKeyName.
         //             Used to authenticate the user (analogous to a password)
-        //path: The full path to the choreo to be executed (relative to the root of the 
+        //path: The full path to the Choreo to be executed (relative to the root of the 
         //      user's account.)
-        //inputSet: the set of inputs needed by the choreo.
+        //inputSet: the set of inputs needed by the Choreo.
         //          May be an empty ChoreoInputSet.
-        //outputSet: the set of output filters to be applied to the choreo results.
+        //outputSet: the set of output filters to be applied to the Choreo results.
         //           May be an empty ChoreoOutputSet
-        //preset: the ChoreoPreset to be used with the choreo execution. 
+        //preset: the ChoreoPreset to be used with the Choreo execution. 
         //        May be an empty ChoreoPreset.
         int executeChoreo(
                 uint16_t requestId,

--- a/src/utility/TembooOneWire.cpp
+++ b/src/utility/TembooOneWire.cpp
@@ -16,7 +16,7 @@ Temboo Version:
   Class renamed to resolve a distribution issue.
 
 Version 2.3:
-  Unknonw chip fallback mode, Roger Clark
+  Unknown chip fallback mode, Roger Clark
   Teensy-LC compatibility, Paul Stoffregen
   Search bug fix, Love Nystrom
 

--- a/src/utility/TembooOneWire.h
+++ b/src/utility/TembooOneWire.h
@@ -246,7 +246,7 @@ void directWriteHigh(volatile IO_REG_TYPE *base, IO_REG_TYPE pin)
 #define DIRECT_WRITE_HIGH(base, pin)    digitalWrite(pin, HIGH)
 #define DIRECT_MODE_INPUT(base, pin)    pinMode(pin,INPUT)
 #define DIRECT_MODE_OUTPUT(base, pin)   pinMode(pin,OUTPUT)
-#warning "OneWire. Fallback mode. Using API calls for pinMode,digitalRead and digitalWrite. Operation of this library is not guaranteed on this architecture."
+#warning "OneWire. Fallback mode. Using API calls for pinMode, digitalRead and digitalWrite. Operation of this library is not guaranteed on this architecture."
 
 #endif
 
@@ -270,7 +270,7 @@ class TembooOneWire
 
     // Perform a 1-Wire reset cycle. Returns 1 if a device responds
     // with a presence pulse.  Returns 0 if there is no device or the
-    // bus is shorted or otherwise held low for more than 250uS
+    // bus is shorted or otherwise held low for more than 250 us
     uint8_t reset(void);
 
     // Issue a 1-Wire rom select command, you do the reset first.
@@ -347,7 +347,7 @@ class TembooOneWire
     // @param inverted_crc - The two CRC16 bytes in the received data.
     //                       This should just point into the received data,
     //                       *not* at a 16-bit integer.
-    // @param crc - The crc starting value (optional)
+    // @param crc - The CRC starting value (optional)
     // @return True, iff the CRC matches.
     static bool check_crc16(const uint8_t* input, uint16_t len, const uint8_t* inverted_crc, uint16_t crc = 0);
 
@@ -361,7 +361,7 @@ class TembooOneWire
     //      byte order than the two bytes you get from 1-Wire.
     // @param input - Array of bytes to checksum.
     // @param len - How many bytes to use.
-    // @param crc - The crc starting value (optional)
+    // @param crc - The CRC starting value (optional)
     // @return The CRC16, as defined by Dallas Semiconductor.
     static uint16_t crc16(const uint8_t* input, uint16_t len, uint16_t crc = 0);
 #endif

--- a/src/utility/TembooSession.cpp
+++ b/src/utility/TembooSession.cpp
@@ -154,7 +154,7 @@ int TembooSession::executeChoreo(
         // send the standard accept header
         qsendlnProgmem(HEADER_ACCEPT);
         
-        // send our custom account name neader
+        // send our custom account name header
         qsendProgmem(HEADER_ORG);
         qsend(accountName);
         qsendlnProgmem(HEADER_DOM);

--- a/src/utility/TembooSession.h
+++ b/src/utility/TembooSession.h
@@ -31,7 +31,7 @@
 
 #ifndef TEMBOO_SEND_QUEUE_SIZE
 
-// Some network interfaces (i.e. ethernet or WiFi shields) can only accept
+// Some network interfaces (i.e. Ethernet or WiFi shields) can only accept
 // a limited amount of data.  If you try to send more than the limit, the excess
 // is just lost.  However, sending one character at a time is very inefficient.
 // To deal with this situation, we queue up TEMBOO_SEND_QUEUE_SIZE bytes to send
@@ -57,20 +57,20 @@ class TembooSession {
         //port: OPTIONAL port number to use with the IPAddress. Usually only used for testing.
         TembooSession(Client& client, IPAddress serverAddr=INADDR_NONE, uint16_t port=80);
 
-        //executeChoreo sends a choreo execution request to the Temboo system.
+        //executeChoreo sends a Choreo execution request to the Temboo system.
         //              Does not wait for a response (that's a job for whoever owns the Client.)
         //accountName: the name of the user's account at Temboo.
         //appKeyName: the name of an application key in the user's account to use 
         //            for this execution (analogous to a user name).
         //appKeyValue: the value of the application key named in appKeyName.
         //             Used to authenticate the user (analogous to a password)
-        //path: The full path to the choreo to be executed (relative to the root of the 
+        //path: The full path to the Choreo to be executed (relative to the root of the 
         //      user's account.)
-        //inputSet: the set of inputs needed by the choreo.
+        //inputSet: the set of inputs needed by the Choreo.
         //          May be an empty ChoreoInputSet.
-        //outputSet: the set of output filters to be applied to the choreo results.
+        //outputSet: the set of output filters to be applied to the Choreo results.
         //           May be an empty ChoreoOutputSet
-        //preset: the ChoreoPreset to be used with the choreo execution. 
+        //preset: the ChoreoPreset to be used with the Choreo execution. 
         //        May be an empty ChoreoPreset.
         int executeChoreo(const char* accountName, 
                 const char* appKeyName, 

--- a/src/utility/TembooWebSocketRequestHandles.c
+++ b/src/utility/TembooWebSocketRequestHandles.c
@@ -172,8 +172,8 @@ WSMessageRequest handleSetRequest(char** saveptr, TembooSensor** sensorTable, in
 
 // Parse out the error message while ignoring escaped characters.
 // This functions acts like strstr where it will move saveptr
-// to the index past the delimeter ('|' in this case), add '\0'
-// where the delimeter is, and return the pointer of the error message
+// to the index past the delimiter ('|' in this case), add '\0'
+// where the delimiter is, and return the pointer of the error message
 char* getErrorMessage(char** saveptr) {
     if (saveptr == NULL || *saveptr == NULL) {
         return NULL;


### PR DESCRIPTION
This PR provides the standardized [GitHub Actions](https://github.com/features/actions)-based CI configuration for Arduino libraries.

### Dependabot

Dependabot will periodically check the versions of all actions used in the repository's workflows. If any are found to be outdated, it will submit a pull request to update them.

NOTE: Dependabot's PRs will sometimes try to pin to the patch version of the action (e.g., updating `uses: foo/bar@v1` to `uses: foo/bar@v2.3.4`). When the action author has [provided a major version ref](https://docs.github.com/en/actions/creating-actions/about-actions#using-release-management-for-actions), use that instead (e.g., `uses: foo/bar@v2`). Once the major version has been updated in the workflow, Dependabot should not submit an update PR again until the next major version bump. So even if the PRs from Dependabot are not always exactly correct, their value lies in bringing the maintainer's attention to the fact that the action version in use is outdated. Dependabot will automatically close its PR once the workflow has been updated.

More information:
https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot

### Spell check

On every push, pull request, and periodically, use [the `codespell-project/actions-codespell` action](https://github.com/codespell-project/actions-codespell) to check for commonly misspelled words.

In the event of a false positive, the problematic word should be added, in all lowercase, to the `ignore-words-list` field of `./.codespellrc`. Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore list. The ignore list is comma-separated with no spaces.

### Arduino Lint

On every push, pull request, and periodically, run [Arduino Lint](https://github.com/arduino/arduino-lint) to check for common problems not related to the project code.

### Compile examples

On every push or pull request that affects library source or example files, and periodically, use [the `arduino/compile-sketches` action](https://github.com/arduino/compile-sketches) to compile all example sketches for the specified boards.

### Report size deltas

On creation or commit to a pull request, use [the `arduino/report-size-deltas` action](https://github.com/arduino/report-size-deltas) to comment a report of the resulting change in memory usage of the examples to the PR thread.

---
Fixes https://github.com/arduino-libraries/Temboo/issues/14