### PR TITLE
Fix spell check ~false positive by ignoring word

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,7 @@
 # See: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
-ignore-words-list = tre,messanger
+ignore-words-list = inflight,tre,messanger
 check-filenames =
 check-hidden =
 skip = ./.git


### PR DESCRIPTION
In the latest release of [the **codespell** tool](https://github.com/codespell-project/codespell) used for automated spell checking of the files of this project, the word "inflight" was added to the codespell misspelled words dictionary as a misspelling of "in-flight".

The "inflight" spelling occurs in a comment in `src/utility/MQTTClient.h`, which caused the spell check to start failing.

https://github.com/arduino-libraries/Temboo/runs/8087250150?check_suite_focus=true#step:4:17

```text
Error: ./src/utility/MQTTClient.h:708: inflight ==> in-flight
```

Although that is surely correct for the prose word, "inflight" seems to be somewhat common in the context of MQTT, and also occurs in names in the code, so I'm not sure that "correcting" the current spelling would be the right thing to do. It is also probably questionable whether this file should be edited at all, since it appears it might be an externally maintained resource (meaning that any changes to it in this repo make a hypothetical sync from upstream more difficult).

All in all, it seems best to simply configure **codespell** to ignore the problematic word.