### PR TITLE
Correct misspelled word in comment

### DIFF
--- a/src/TembooMQTTEdgeDevice.h
+++ b/src/TembooMQTTEdgeDevice.h
@@ -72,7 +72,7 @@
 #define TEMBOO_ERROR_MQTT_BUFFER_OVERFLOW (906)
 /*
  * There was more data to be returned in the packet data than could
- * fit in the return buffer. Incease MAX_RESPONSE_SIZE to read more
+ * fit in the return buffer. Increase MAX_RESPONSE_SIZE to read more
  * of the packet response
  */
 #define TEMBOO_ERROR_MQTT_DATA_TRUNCATED  (907)


### PR DESCRIPTION
The misspelled word in the comment was causing the spell check workflow to fail following an update in the codespell misspelled words dictionary.