### PR TITLE
Fix regression report-size-deltas after updating upload-artifact.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -37,29 +37,36 @@ jobs:
             platforms: |
               - name: arduino:avr
             yun: false
+            artifact-name-suffix: arduino-avr-uno
           - fqbn: arduino:avr:mega
             platforms: |
               - name: arduino:avr
             yun: false
+            artifact-name-suffix: arduino-avr-mega
           - fqbn: arduino:avr:leonardo
             platforms: |
               - name: arduino:avr
             yun: false
+            artifact-name-suffix: arduino-avr-leonardo
           - fqbn: arduino:avr:yun
             platforms: |
               - name: arduino:avr
             yun: true
+            artifact-name-suffix: arduino-avr-yun
           - fqbn: arduino:megaavr:uno2018
             platforms: |
               - name: arduino:megaavr
             yun: false
+            artifact-name-suffix: arduino-megaavr-uno2018
           - fqbn: arduino:sam:arduino_due_x_dbg
             platforms: |
               - name: arduino:sam
+            artifact-name-suffix: arduino-sam-arduino_due_x_dbg
           - fqbn: arduino:samd:arduino_zero_edbg
             platforms: |
               - name: arduino:samd
             yun: false
+            artifact-name-suffix: arduino-samd-arduino_zero_edbg
 
         # make board type-specific customizations to the matrix jobs
         include:
@@ -97,4 +104,4 @@ jobs:
         with:
           if-no-files-found: error
           path: ${{ env.SKETCHES_REPORTS_PATH }}
-          name: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: sketches-report-${{ matrix.board.artifact-name-suffix }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Comment size deltas reports to PRs
         uses: arduino/report-size-deltas@v1
         with:
-          # The name of the workflow artifact created by the sketch compilation workflow
-          sketches-reports-source: sketches-reports
+          # Regex matching the names of the workflow artifacts created by the "Compile Examples" workflow
+          sketches-reports-source: ^sketches-report-.+


### PR DESCRIPTION
For more information see https://github.com/arduino/report-size-deltas/blob/main/docs/FAQ.md#size-deltas-report-workflow-triggered-by-schedule-event .