### PR TITLE
Correct typos in comments

### DIFF
--- a/src/utility/TembooDS18B20.cpp
+++ b/src/utility/TembooDS18B20.cpp
@@ -53,7 +53,7 @@ int tembooDS18B20Read(void* sensorConfig) {
 }
 
 void tembooDS18B20Begin(__attribute__((unused)) void* sensorConfig) {
-	// all of the initializtion is done in init
+	// all of the initialization is done in init
 	return;
 }
 

--- a/src/utility/TembooGPIO.c
+++ b/src/utility/TembooGPIO.c
@@ -52,7 +52,7 @@ void tembooAnalogWrite(void* sensorConfig, int val) {
 }
 
 void tembooGPIOBegin(__attribute__((unused)) void* sensorConfig) {
-	// all of the initializtion is done in init
+	// all of the initialization is done in init
 	return;
 }
 


### PR DESCRIPTION
The [**codespell**](https://github.com/codespell-project/codespell) spellchecker tool is used to automatically detect commonly misspelled words in the files of this project.

The misspelled words dictionary was expanded in the [latest release](https://github.com/codespell-project/codespell/releases/tag/v2.3.0) of codespell, which resulted in the detection of
misspelled words in the project's comments:

https://github.com/arduino-libraries/Temboo/actions/runs/9265735251

> spellcheck: src/utility/TembooDS18B20.cpp#L56
initializtion ==> initialization
>
>spellcheck: src/utility/TembooGPIO.c#L55
initializtion ==> initialization

The typos are hereby corrected, which will restore the spell check to a passing state.

