### PR TITLE
Use standardized `maintainer` metadata property value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,6 +1,6 @@
 name=Temboo
 author=Temboo
-maintainer=Temboo <support@temboo.com>
+maintainer=Arduino <info@arduino.cc>
 sentence=This library enables calls to Temboo, a platform that connects Arduino boards to 100+ APIs, databases, code utilities and more. 
 paragraph=Use this library to connect your Arduino board to Temboo, making it simple to interact with a vast array of web-based resources and services.
 category=Communication


### PR DESCRIPTION
The `maintainer` property of the [`library.properties` metadata file](https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata) defines the entity responsible for maintenance of the library.

In the libraries that are under Arduino's maintainership, it is standard practice to set the `maintainer` property to the general purpose value `Arduino <info@arduino.cc>`.

Previously, instead of that standard value, this library's `maintainer` property defined a former partner company which hasn't had any involvement in the library for many years, and is unlikely to do so at any point in the future. So the metadata is changed to use the standard value.